### PR TITLE
Updated DMRIDUpdate.sh script to use the new database.radioid.net API

### DIFF
--- a/DMRIDUpdate.sh
+++ b/DMRIDUpdate.sh
@@ -86,6 +86,6 @@ then
 fi
 
 # Generate new file
-curl -s -N "https://database.radioid.net/api/dmr/user/?id=%" | jq -r '.results[] | [.id, .callsign, .fname] | @csv' | sed -e 's/"//g' | sed -e 's/,/ /g' > ${DMRIDFILE}
+curl -s -N "https://database.radioid.net/static/users.json" | jq -r '.users[] | [.radio_id, .callsign, .fname] | @csv' | sed -e 's/"//g' | sed -e 's/,/ /g' > ${DMRIDFILE}
 
 


### PR DESCRIPTION
Updated DMRIDUpdate.sh script to use the new database.radioid.net API that was recently changed this summer. The old API is deprecated and non-functional so that breaks the script